### PR TITLE
Conflict with symfony/framework-bundle < 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,8 @@
         "symfony/debug-pack": "*",
         "symfony/profiler-pack": "*",
         "symfony/maker-bundle": "^1.0"
+    },
+    "conflict": {
+        "symfony/framework-bundle": "<5.0",
     }
 }


### PR DESCRIPTION
`composer req webapp` on a 4.4 app fails because notifier and string are not available on 4.4.

I'd recommend push-forcing the v1.0.0 after merging this to prevent composer from installing a bad v1.0.0 on 4.4