### PR TITLE
Add NelmioSecurityBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "MIT",
     "description": "A webapp pack on top of the default skeleton",
     "require": {
+        "nelmio/security-bundle": "^3.0",
         "symfony/asset": "*",
         "symfony/debug-pack": "*",
         "symfony/doctrine-messenger": "*",


### PR DESCRIPTION
The NelmioSecurityBundle has been part of the official Symfony recipes repo since the start. The headers provided by the bundle create a safe start for web applications. I think the webapp-pack is the perfect place to install this bundle, giving all users a safe start.

We might need to have a look at the default recipe again: https://github.com/symfony/recipes/blob/main/nelmio/security-bundle/2.4/config/packages/nelmio_security.yaml It should provide a safe start, but without adding technical depth to an application (e.g. do we want to disable framing by default, like currently done, or would this confuse new users too much?).

cc @franmomu