### PR TITLE
Remove webpack-encore-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "symfony/translation": "*",
         "symfony/twig-pack": "*",
         "symfony/validator": "*",
-        "symfony/web-link": "*",
-        "symfony/webpack-encore-bundle": "^1.12"
+        "symfony/web-link": "*"
     },
     "require-dev": {
         "symfony/debug-pack": "*",


### PR DESCRIPTION
It forces running npm et al. That's not providing a good first experience.
See https://github.com/symfony/symfony/pull/46689 for an alternative approach.
/cc @weaverryan @[GromNaN](https://github.com/GromNaN)