### PR TITLE
Adding AssetMapper & Stimulus+Turbo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "description": "A webapp pack on top of the default skeleton",
     "require": {
         "symfony/asset": "*",
+        "symfony/asset-mapper": "*",
         "symfony/debug-pack": "*",
         "symfony/doctrine-messenger": "*",
         "symfony/expression-language": "*",
@@ -25,6 +26,8 @@
         "symfony/test-pack": "*",
         "symfony/translation": "*",
         "symfony/twig-pack": "*",
+        "symfony/stimulus-bundle": "*",
+        "symfony/ux-turbo": "*",
         "symfony/validator": "*",
         "symfony/web-link": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
         "symfony/profiler-pack": "*",
         "symfony/security-bundle": "*",
         "symfony/serializer-pack": "*",
+        "symfony/stimulus-bundle": "*",
         "symfony/string": "*",
         "symfony/test-pack": "*",
         "symfony/translation": "*",
         "symfony/twig-pack": "*",
-        "symfony/stimulus-bundle": "*",
         "symfony/ux-turbo": "*",
         "symfony/validator": "*",
         "symfony/web-link": "*"


### PR DESCRIPTION
Hi!

The webapp already installs Twig & is aimed at "web apps" that return HTML. So, in 6.4, we should also give them a proper asset setup with AssetMapper, Stimulus & Turbo.

I've just tested this locally - it works great. All I had to do was `make:controller Home` then to go `/home` to see the site with JS & CSS already loaded. If I had a 2nd page and link, the navigation is AJAX-powered 🥳 .

Cheers!